### PR TITLE
Added ability to configure number of shards and replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ curl -XPUT localhost:9200/_river/my_twitter_river/_meta -d '
         "index" : "my_twitter_river",
         "type" : "status",
         "bulk_size" : 100,
-        "flush_interval" : "5s"
+        "flush_interval" : "5s",
+        "shards" : 5,
+        "replicas" : 1
     }
 }
 '

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ curl -XPUT localhost:9200/_river/my_twitter_river/_meta -d '
         "bulk_size" : 100,
         "flush_interval" : "5s",
         "shards" : 5,
-        "replicas" : 1
+        "replicas" : 1,
+        "newIndexFrequency" : "none"
     }
 }
 '
@@ -96,6 +97,11 @@ Note that if you define a filter (see [next section](#filtered-stream)), type wi
 
 Tweets will be indexed once a `bulk_size` of them have been accumulated (default to `100`)
 or every `flush_interval` period (default to `5s`).
+
+A new index may automatically be created after a period of time by using the `newIndexFrequency`
+parameter. Valid options are `daily`, `weekly`, `monthly`, and `yearly` to have a new index
+created at those respective frequencies with an automatic alias pointing to the indexName which
+groups them all together. A value of `none` (default) will keep everything in a single index.
 
 Filtered Stream
 ===============

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>1.0.0</elasticsearch.version>
+        <elasticsearch.version>1.1.0</elasticsearch.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
A modification that allows a user to configure the number of shards and/or the number of replicas when the index is automatically created by the river plugin.

Also, since this is essentially time series data, an option was added that allows the user the option of having the river automatically create new indexes either daily, weekly, monthly, or yearly (or use a single index) and have an automatic alias combining all the indexes together as a single query point. (i.e. number of indices @ http://www.elasticsearch.org/tutorials/using-elasticsearch-for-logs/)