### PR TITLE
Add "restart after install" line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ In order to install the plugin, run:
 bin/plugin -install elasticsearch/elasticsearch-river-twitter/2.4.1
 ```
 
+After installing the plugin you need to restart elasticsearch.
+
 You need to install a version matching your Elasticsearch version:
 
 |       Elasticsearch    |Twitter River Plugin|                                                            Docs                                                                   |


### PR DESCRIPTION
Without restarting the elasticsearch instance the class "twitter" could not be found, making restarting a requirement.