### PR TITLE
[Test] Mapping has not been created yet

### DIFF
--- a/src/test/java/org/elasticsearch/river/twitter/test/TwitterIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/river/twitter/test/TwitterIntegrationTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.river.twitter.test;
 
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.base.Predicate;
@@ -150,6 +151,8 @@ public class TwitterIntegrationTest extends ElasticsearchIntegrationTest {
                     logger.info("  -> got {} docs in {} index", response.getCount(), getDbName());
                     return response.getCount() >= numDocs;
                 } catch (IndexMissingException e) {
+                    return false;
+                } catch (SearchPhaseExecutionException e) {
                     return false;
                 }
             }


### PR DESCRIPTION
It could happen when you run a test the index has been created but the mapping has not been applied yet. It looks like a rare race condition but that could happen and throw a `SearchPhaseExecutionException`:

```
org.elasticsearch.action.search.SearchPhaseExecutionException: Failed to execute phase [query], all shards failed; shardFailures {[HJUPDFCcSWuAt0C1twBcvg][testgeo_as_array][0]: RemoteTransportException[[node_s1][local[2]][indices:data/read/search[phase/query]]]; nested: SearchParseException[[testgeo_as_array][0]: from[-1],size[-1]: Parse Failure [Failed to parse source [{"post_filter":{"geo_distance":{"status.location":[0.0,0.0],"distance":"10000.0km"}},"fields":["_source","location"]}]]]; nested: QueryParsingException[[testgeo_as_array] failed to find geo_point field [status.location]]; }{[lTPKlAx9RAeCOj7iyBnCkQ][testgeo_as_array][1]: RemoteTransportException[[node_s1][local[2]][indices:data/read/search[phase/query]]]; nested: SearchParseException[[testgeo_as_array][1]: from[-1],size[-1]: Parse Failure [Failed to parse source [{"post_filter":{"geo_distance":{"status.location":[0.0,0.0],"distance":"10000.0km"}},"fields":["_source","location"]}]]]; nested: QueryParsingException[[testgeo_as_array] failed to find geo_point field [status.location]]; }{[rTyn7S0nQ6epUKd35ptbPw][testgeo_as_array][2]: RemoteTransportException[[node_s1][local[2]][indices:data/read/search[phase/query]]]; nested: SearchParseException[[testgeo_as_array][2]: from[-1],size[-1]: Parse Failure [Failed to parse source [{"post_filter":{"geo_distance":{"status.location":[0.0,0.0],"distance":"10000.0km"}},"fields":["_source","location"]}]]]; nested: QueryParsingException[[testgeo_as_array] failed to find geo_point field [status.location]]; }{[4-7InzuaTsGSOc265s6WeQ][testgeo_as_array][3]: RemoteTransportException[[node_s1][local[2]][indices:data/read/search[phase/query]]]; nested: SearchParseException[[testgeo_as_array][3]: from[-1],size[-1]: Parse Failure [Failed to parse source [{"post_filter":{"geo_distance":{"status.location":[0.0,0.0],"distance":"10000.0km"}},"fields":["_source","location"]}]]]; nested: QueryParsingException[[testgeo_as_array] failed to find geo_point field [status.location]]; }{[-Ts5IKqzToK5XmxNq7SJBQ][testgeo_as_array][4]: RemoteTransportException[[node_s1][local[2]][indices:data/read/search[phase/query]]]; nested: SearchParseException[[testgeo_as_array][4]: from[-1],size[-1]: Parse Failure [Failed to parse source [{"post_filter":{"geo_distance":{"status.location":[0.0,0.0],"distance":"10000.0km"}},"fields":["_source","location"]}]]]; nested: QueryParsingException[[testgeo_as_array] failed to find geo_point field [status.location]]; }
```

Closes #94.